### PR TITLE
Port repository to Python 3

### DIFF
--- a/const.py
+++ b/const.py
@@ -62,7 +62,7 @@ BinOps = dict([
     (1, ("+", operator.add)),
     (2, ("-", operator.sub)),
     (3, ("*", operator.mul)),
-    (4, ("/", operator.div)),
+    (4, ("/", operator.truediv)),
     (5, ("cons", runtime.cons)),
     (6, ("=", operator.eq)),
     (7, (">", operator.gt)),

--- a/parser.py
+++ b/parser.py
@@ -1,5 +1,6 @@
 import re
-from itertools import ifilter
+from functools import reduce
+
 
 
 class ParseException(Exception):
@@ -68,7 +69,7 @@ class Lexer(object):
     def __init__(self, src):
         self.s = src
         self.buffer = []
-        self.tokens = ifilter(lambda x: x.type not in self.skip, self.tokenize(src))
+        self.tokens = filter(lambda x: x.type not in self.skip, self.tokenize(src))
 
     def tokenize(self, s):
         lineno = 1
@@ -81,7 +82,7 @@ class Lexer(object):
             if not m:
                 break
 
-            groups = filter(lambda x: x[1] is not None, m.groupdict().items())
+            groups = [(n, v) for n, v in m.groupdict().items() if v is not None]
             assert len(groups) == 1
             name, value = groups[0]
 
@@ -112,8 +113,8 @@ class Lexer(object):
             return self.buffer.pop()
         else:
             try:
-                next = self.tokens.next()
-                return next
+                nxt = next(self.tokens)
+                return nxt
             except StopIteration:
                 return
 

--- a/runtime.py
+++ b/runtime.py
@@ -1,4 +1,4 @@
-import cStringIO
+import io
 
 
 class Closure(object):
@@ -109,7 +109,7 @@ class LinkList(object):
 
     def __str__(self):
         n = self
-        sb = cStringIO.StringIO()
+        sb = io.StringIO()
         sb.write("(%s" % self.v)
         try:
             while n.next:

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import unittest
 from parser import Parser, Transform, traverse
 import code
 import vm
-import cStringIO
+import io
 import runtime
 import functools
 
@@ -60,7 +60,7 @@ class Lisp(unittest.TestCase):
         m.start()
 
     def setUp(self):
-        outputs = cStringIO.StringIO()
+        outputs = io.StringIO()
 
         def display(*args):
             for arg in args:

--- a/vm.py
+++ b/vm.py
@@ -84,7 +84,7 @@ class VM(object):
             try:
                 operator, operand = insts[pc]
                 if self.debug:
-                    print self.inst2str(insts[pc])
+                    print(self.inst2str(insts[pc]))
             except IndexError:
                 return
 


### PR DESCRIPTION
## Summary
- update imports for `io` and remove Python2 only `cStringIO`
- replace removed functions (`ifilter`, `operator.div`, `obj.next`) with Python3 equivalents
- use print function

## Testing
- `python3 tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6854caaff5c88323a14473343dd38a25